### PR TITLE
Fixes a small problem if a issue without assignee throw error  #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,7 +178,9 @@ function generateLog(milestone, api) {
                 const update = milestone.created_at.substr(0, 10);
                 const issues = JSON.parse(body);
                 let content = issues.map((issue) => {
-                    return `- ${issue.title} (#${issue.iid} @${issue.assignee.username})`;
+                    // handle unassigned issue
+                    let username = issue.assignee && issue.assignee.username ? ` @${issue.assignee.username}` : ''
+                    return `- ${issue.title} (#${issue.iid}${username})`;
                 });
                 content.unshift(`## ${version} - ${update}`);
                 resolve({


### PR DESCRIPTION
data:

``` js
{ id: 269,
    iid: 28,
    project_id: 471,
    title: '排查 CPU 占用过高',
    // without `assignee`
    // assignee: {}
}
```
